### PR TITLE
Added FormComponent and tests, fixed fixtures for UCSBOrganizations

### DIFF
--- a/frontend/src/fixtures/ucsbOrganizationFixtures.js
+++ b/frontend/src/fixtures/ucsbOrganizationFixtures.js
@@ -3,26 +3,26 @@ const ucsbOrganizationFixtures = {
         "orgCode": "ZPR",
         "orgTranslationShort": "ZETA PHI RHO",
         "orgTranslation": "ZETA PHI RHO",
-        "inactive": false
+        "inactive": "false"
     },
     threeOrganizations: [
         {
             "orgCode": "KRC",
             "orgTranslationShort": "KOREAN RADIO CLUB",
             "orgTranslation": "KOREAN RADIO CLUB",
-            "inactive": false
+            "inactive": "false"
         },
         {
             "orgCode": "ZPR",
             "orgTranslationShort": "ZETA PHI RHO",
             "orgTranslation": "ZETA PHI RHO",
-            "inactive": false
+            "inactive": "false"
         },
         {
             "orgCode": "SIGEP",
             "orgTranslationShort": "SIG PHI EP",
             "orgTranslation": "SIGMA PHI EPSILON",
-            "inactive": false
+            "inactive": "false"
         }
     ]
 };

--- a/frontend/src/main/components/UCSBOrganization/UCSBOrganizationForm.js
+++ b/frontend/src/main/components/UCSBOrganization/UCSBOrganizationForm.js
@@ -1,0 +1,105 @@
+import { Button, Form } from 'react-bootstrap';
+import { useForm } from 'react-hook-form'
+import { useNavigate } from 'react-router-dom';
+
+function UCSBOrganizationForm({ initialContents, submitAction, buttonLabel = "Create" }) {
+
+    
+    // Stryker disable all
+    const {
+        register,
+        formState: { errors },
+        handleSubmit,
+    } = useForm(
+        { defaultValues: initialContents || {}, }
+    );
+    // Stryker restore all
+   
+    const navigate = useNavigate();
+
+    const testIdPrefix = "UCSBOrganizationForm";
+
+    return (
+        <Form onSubmit={handleSubmit(submitAction)}>
+
+            <Form.Group className="mb-3" >
+                <Form.Label htmlFor="orgCode">orgCode</Form.Label>
+                <Form.Control
+                    data-testid={testIdPrefix + "-orgCode"}
+                    id="orgCode"
+                    type="text"
+                    isInvalid={Boolean(errors.orgCode)}
+                    {...register("orgCode", {
+                        required: "orgCode is required."
+                    })}
+                />
+                <Form.Control.Feedback type="invalid">
+                    {errors.orgCode?.message}
+                </Form.Control.Feedback>
+            </Form.Group>
+
+            <Form.Group className="mb-3" >
+                <Form.Label htmlFor="orgTranslationShort">orgTranslationShort</Form.Label>
+                <Form.Control
+                    data-testid={testIdPrefix + "-orgTranslationShort"}
+                    id="orgTranslationShort"
+                    type="text"
+                    isInvalid={Boolean(errors.orgTranslationShort)}
+                    {...register("orgTranslationShort", {
+                        required: "orgTranslationShort is required."
+                    })}
+                />
+                <Form.Control.Feedback type="invalid">
+                    {errors.orgTranslationShort?.message}
+                </Form.Control.Feedback>
+            </Form.Group>
+
+            <Form.Group className="mb-3" >
+                <Form.Label htmlFor="orgTranslation">orgTranslation</Form.Label>
+                <Form.Control
+                    data-testid={testIdPrefix + "-orgTranslation"}
+                    id="orgTranslation"
+                    type="text"
+                    isInvalid={Boolean(errors.orgTranslation)}
+                    {...register("orgTranslation", {
+                        required: "orgTranslation is required."
+                    })}
+                />
+                <Form.Control.Feedback type="invalid">
+                    {errors.orgTranslation?.message}
+                </Form.Control.Feedback>
+            </Form.Group>
+
+            <Form.Group className="mb-3" >
+                <Form.Label htmlFor="inactive">inactive</Form.Label>
+                <Form.Select
+                    data-testid={testIdPrefix + "-inactive"}
+                    id="inactive"
+                    {...register("inactive")}
+                >
+                    <option value="true">True</option>
+                    <option value="false">False</option>
+                </Form.Select>
+            </Form.Group>
+
+
+            <Button
+                type="submit"
+                data-testid={testIdPrefix + "-submit"}
+            >
+                {buttonLabel}
+            </Button>
+            <Button
+                variant="Secondary"
+                onClick={() => navigate(-1)}
+                data-testid={testIdPrefix + "-cancel"}
+            >
+                Cancel
+            </Button>
+
+        </Form>
+
+    )
+}
+
+export default UCSBOrganizationForm;

--- a/frontend/src/stories/components/UCSBOrganization/UCSBOrganization.stories/UCSBOrganization.stories.js
+++ b/frontend/src/stories/components/UCSBOrganization/UCSBOrganization.stories/UCSBOrganization.stories.js
@@ -1,0 +1,36 @@
+import React from 'react';
+import UCSBOrganizationForm from "main/components/UCSBOrganization/UCSBOrganizationForm"
+import { ucsbOrganizationFixtures } from 'fixtures/ucsbOrganizationFixtures';
+
+export default {
+    title: 'components/UCSBOrganization/UCSBOrganizationForm',
+    component: UCSBOrganizationForm
+};
+
+
+const Template = (args) => {
+    return (
+        <UCSBOrganizationForm {...args} />
+    )
+};
+
+export const Create = Template.bind({});
+
+Create.args = {
+    buttonLabel: "Create",
+    submitAction: (data) => {
+        console.log("Submit was clicked with data: ", data); 
+        window.alert("Submit was clicked with data: " + JSON.stringify(data));
+   }
+};
+
+export const Update = Template.bind({});
+
+Update.args = {
+    initialContents: ucsbOrganizationFixtures.oneOrganization,
+    buttonLabel: "Update",
+    submitAction: (data) => {
+        console.log("Submit was clicked with data: ", data); 
+        window.alert("Submit was clicked with data: " + JSON.stringify(data));
+   }
+};

--- a/frontend/src/tests/components/UCSBOrganization/UCSBOrganizationForm.test.js
+++ b/frontend/src/tests/components/UCSBOrganization/UCSBOrganizationForm.test.js
@@ -1,0 +1,100 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { BrowserRouter as Router } from "react-router-dom";
+
+import UCSBOrganizationForm from "main/components/UCSBOrganization/UCSBOrganizationForm";
+import { ucsbOrganizationFixtures } from "fixtures/ucsbOrganizationFixtures";
+
+import { QueryClient, QueryClientProvider } from "react-query";
+
+const mockedNavigate = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+    ...jest.requireActual('react-router-dom'),
+    useNavigate: () => mockedNavigate
+}));
+
+describe("UCSBOrganizationForm tests", () => {
+    const queryClient = new QueryClient();
+
+    const expectedHeaders = ["orgCode", "orgTranslationShort", "orgTranslationShort", "inactive"];
+    const testId = "UCSBOrganizationForm";
+
+    test("renders correctly with no initialContents", async () => {
+        render(
+            <QueryClientProvider client={queryClient}>
+                <Router>
+                    <UCSBOrganizationForm />
+                </Router>
+            </QueryClientProvider>
+        );
+
+        expect(await screen.findByText(/Create/)).toBeInTheDocument();
+
+        expectedHeaders.forEach((headerText) => {
+            const header = screen.getByText(headerText);
+            expect(header).toBeInTheDocument();
+        });
+
+    });
+
+    test("renders correctly when passing in initialContents", async () => {
+        render(
+            <QueryClientProvider client={queryClient}>
+                <Router>
+                    <UCSBOrganizationForm initialContents={ucsbOrganizationFixtures.oneOrganization} />
+                </Router>
+            </QueryClientProvider>
+        );
+
+        expect(await screen.findByText(/Create/)).toBeInTheDocument();
+
+        expectedHeaders.forEach((headerText) => {
+            const header = screen.getByText(headerText);
+            expect(header).toBeInTheDocument();
+        });
+
+        expect(await screen.findByTestId(`${testId}-orgCode`)).toBeInTheDocument();
+        expect(await screen.findByTestId(`${testId}-orgTranslationShort`)).toBeInTheDocument();
+        expect(await screen.findByTestId(`${testId}-orgTranslation`)).toBeInTheDocument();
+        expect(await screen.findByTestId(`${testId}-inactive`)).toBeInTheDocument();
+        expect(screen.getByText(`orgCode`)).toBeInTheDocument();
+    });
+
+
+    test("that navigate(-1) is called when Cancel is clicked", async () => {
+        render(
+            <QueryClientProvider client={queryClient}>
+                <Router>
+                    <UCSBOrganizationForm />
+                </Router>
+            </QueryClientProvider>
+        );
+        expect(await screen.findByTestId(`${testId}-cancel`)).toBeInTheDocument();
+        const cancelButton = screen.getByTestId(`${testId}-cancel`);
+
+        fireEvent.click(cancelButton);
+
+        await waitFor(() => expect(mockedNavigate).toHaveBeenCalledWith(-1));
+    });
+
+    test("that the correct validations are performed", async () => {
+        render(
+            <QueryClientProvider client={queryClient}>
+                <Router>
+                    <UCSBOrganizationForm />
+                </Router>
+            </QueryClientProvider>
+        );
+
+        expect(await screen.findByText(/Create/)).toBeInTheDocument();
+        const submitButton = screen.getByText(/Create/);
+        fireEvent.click(submitButton);
+
+        expect(await screen.findByTestId(`${testId}-submit`)).toBeInTheDocument();
+        expect(screen.getByText(/orgCode is required./)).toBeInTheDocument();
+        expect(screen.getByText(/orgTranslationShort is required./)).toBeInTheDocument();
+        expect(screen.getByText(/orgTranslation is required./)).toBeInTheDocument();
+        
+    });
+
+});


### PR DESCRIPTION
In this PR, I have added the ability to create and update a UCSB Organization on the storybook frontend. 

<img width="1343" alt="Screenshot 2024-05-09 at 8 09 25 PM" src="https://github.com/ucsb-cs156-s24/team03-s24-5pm-4/assets/97566357/20112e0e-6a29-46a4-8e8a-ad84d4bf89c5">
<img width="1337" alt="Screenshot 2024-05-09 at 8 10 15 PM" src="https://github.com/ucsb-cs156-s24/team03-s24-5pm-4/assets/97566357/e1adcd68-4459-45bb-9c31-535ea94783d5">

[Storybook link](https://ucsb-cs156-s24.github.io/team03-s24-5pm-4/storybook/?path=/story/components-ucsborganization-ucsborganizationform--create)

Closes #23 