### PR TITLE
Add Integration & End-To-End tests for Recommendation Requests

### DIFF
--- a/.github/workflows/11-backend-integration.yml
+++ b/.github/workflows/11-backend-integration.yml
@@ -24,6 +24,13 @@ jobs:
          distribution: semeru # See: https://github.com/actions/setup-java#supported-distributions
          java-version-file: ./.java-version
   
-    - name: Run tests with Maven
-      run: INTEGRATION=true mvn -B test-compile failsafe:integration-test 
+    - name: Test compile with Maven
+      env:
+        TEST_PROPERTIES: ${{ secrets.TEST_PROPERTIES }}
+      run: INTEGRATION=true mvn -B test-compile
+      
+    - name: Run IT tests with maven
+      env:
+        TEST_PROPERTIES: ${{ secrets.TEST_PROPERTIES }}
+      run: INTEGRATION=true mvn -B failsafe:integration-test 
       

--- a/.github/workflows/11-backend-integration.yml
+++ b/.github/workflows/11-backend-integration.yml
@@ -32,5 +32,5 @@ jobs:
     - name: Run IT tests with maven
       env:
         TEST_PROPERTIES: ${{ secrets.TEST_PROPERTIES }}
-      run: INTEGRATION=true mvn -B failsafe:integration-test 
+      run: INTEGRATION=true mvn -B failsafe:integration-test failsafe:verify
       

--- a/.github/workflows/11-backend-integration.yml
+++ b/.github/workflows/11-backend-integration.yml
@@ -24,13 +24,6 @@ jobs:
          distribution: semeru # See: https://github.com/actions/setup-java#supported-distributions
          java-version-file: ./.java-version
   
-    - name: Test compile with Maven
-      env:
-        TEST_PROPERTIES: ${{ secrets.TEST_PROPERTIES }}
-      run: INTEGRATION=true mvn -B test-compile
-      
     - name: Run IT tests with maven
-      env:
-        TEST_PROPERTIES: ${{ secrets.TEST_PROPERTIES }}
-      run: INTEGRATION=true mvn -B failsafe:integration-test failsafe:verify
+      run: INTEGRATION=true mvn -B test-compile failsafe:integration-test failsafe:verify
       

--- a/src/main/resources/application-integration.properties
+++ b/src/main/resources/application-integration.properties
@@ -27,6 +27,6 @@ spring.security.oauth2.client.provider.my-oauth-provider.user-name-attribute=sub
 
 app.oauth.login=${OAUTH_LOGIN:${env.OAUTH_LOGIN:/oauth2/authorization/my-oauth-provider}}
 
-app.admin.emails=${ADMIN_EMAILS:${env.ADMIN_EMAILS:admingaucho@ucsb.edu}}
+app.admin.emails=admingaucho@ucsb.edu
 
 app.playwright.headless=${HEADLESS:${env.HEADLESS:true}}

--- a/src/main/resources/application-wiremock.properties
+++ b/src/main/resources/application-wiremock.properties
@@ -27,4 +27,4 @@ spring.security.oauth2.client.provider.my-oauth-provider.user-name-attribute=sub
 
 app.oauth.login=${OAUTH_LOGIN:${env.OAUTH_LOGIN:/oauth2/authorization/my-oauth-provider}}
 
-app.admin.emails=${ADMIN_EMAILS:${env.ADMIN_EMAILS:admingaucho@ucsb.edu}}
+app.admin.emails=admingaucho@ucsb.edu

--- a/src/test/java/edu/ucsb/cs156/example/integration/RecommendationRequestIT.java
+++ b/src/test/java/edu/ucsb/cs156/example/integration/RecommendationRequestIT.java
@@ -1,0 +1,97 @@
+package edu.ucsb.cs156.example.integration;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import edu.ucsb.cs156.example.entities.RecommendationRequest;
+import edu.ucsb.cs156.example.repositories.RecommendationRequestRepository;
+import edu.ucsb.cs156.example.repositories.RestaurantRepository;
+import edu.ucsb.cs156.example.repositories.UserRepository;
+import edu.ucsb.cs156.example.services.CurrentUserService;
+import edu.ucsb.cs156.example.services.GrantedAuthoritiesService;
+import edu.ucsb.cs156.example.testconfig.TestConfig;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+
+import java.time.LocalDateTime;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureMockMvc
+@ActiveProfiles("integration")
+@Import(TestConfig.class)
+public class RecommendationRequestIT {
+    @Autowired
+    public CurrentUserService currentUserService;
+
+    @Autowired
+    public GrantedAuthoritiesService grantedAuthoritiesService;
+
+    @Autowired
+    RecommendationRequestRepository recommendationRequestRepository;
+
+    @Autowired
+    public MockMvc mockMvc;
+
+    @Autowired
+    public ObjectMapper mapper;
+
+    @MockBean
+    UserRepository userRepository;
+
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void test_user_can_see_recrequest_when_logged_in() throws Exception{
+        LocalDateTime first = LocalDateTime.parse("2024-04-26T08:08:00");
+        LocalDateTime second = LocalDateTime.parse("2024-04-27T08:08:00");
+        RecommendationRequest recommendationRequest1 = RecommendationRequest.builder()
+                .requesterEmail("djensen2@outlook.com")
+                .professorEmail("pconrad@ucsb.edu")
+                .explanation("masters program")
+                .dateRequested(first)
+                .dateNeeded(second)
+                .done(false)
+                .build();
+
+        recommendationRequestRepository.save(recommendationRequest1);
+
+        MvcResult response = mockMvc.perform(get("/api/recommendationrequest?id=1"))
+                .andExpect(status().isOk()).andReturn();
+
+        String expected = mapper.writeValueAsString(recommendationRequest1);
+        String responseString = response.getResponse().getContentAsString();
+
+        assertEquals(expected, responseString);
+    }
+
+    @Test
+    public void no_sign_in_then_unauthorized() throws Exception {
+        LocalDateTime first = LocalDateTime.parse("2024-04-26T08:08:00");
+        LocalDateTime second = LocalDateTime.parse("2024-04-27T08:08:00");
+        RecommendationRequest recommendationRequest1 = RecommendationRequest.builder()
+                .requesterEmail("djensen2@outlook.com")
+                .professorEmail("pconrad@ucsb.edu")
+                .explanation("masters program")
+                .dateRequested(first)
+                .dateNeeded(second)
+                .done(false)
+                .build();
+
+        recommendationRequestRepository.save(recommendationRequest1);
+        MvcResult response = mockMvc.perform(get("/api/recommendationrequest?id=1"))
+                .andExpect(status().isForbidden()).andReturn();
+    }
+
+}

--- a/src/test/java/edu/ucsb/cs156/example/integration/RecommendationRequestIT.java
+++ b/src/test/java/edu/ucsb/cs156/example/integration/RecommendationRequestIT.java
@@ -2,7 +2,6 @@ package edu.ucsb.cs156.example.integration;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import edu.ucsb.cs156.example.entities.RecommendationRequest;
 import edu.ucsb.cs156.example.repositories.RecommendationRequestRepository;
-import edu.ucsb.cs156.example.repositories.RestaurantRepository;
 import edu.ucsb.cs156.example.repositories.UserRepository;
 import edu.ucsb.cs156.example.services.CurrentUserService;
 import edu.ucsb.cs156.example.services.GrantedAuthoritiesService;
@@ -15,6 +14,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
@@ -23,7 +23,6 @@ import org.springframework.test.web.servlet.MvcResult;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 
 import java.time.LocalDateTime;
 
@@ -32,6 +31,7 @@ import java.time.LocalDateTime;
 @AutoConfigureMockMvc
 @ActiveProfiles("integration")
 @Import(TestConfig.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
 public class RecommendationRequestIT {
     @Autowired
     public CurrentUserService currentUserService;

--- a/src/test/java/edu/ucsb/cs156/example/web/RecommendationRequestWebIT.java
+++ b/src/test/java/edu/ucsb/cs156/example/web/RecommendationRequestWebIT.java
@@ -1,0 +1,50 @@
+package edu.ucsb.cs156.example.web;
+
+import edu.ucsb.cs156.example.WebTestCase;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import static com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
+@ActiveProfiles("integration")
+@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
+public class RecommendationRequestWebIT extends WebTestCase {
+    @Test
+    public void admin_user_can_create_recrequest() throws Exception{
+        setupUser(true);
+        page.getByText("Recommendation Requests").click();
+        page.getByText("Create Recommendation Request").click();
+        assertThat(page.getByText("Create New Recommendation Request")).isVisible();
+
+        page.getByTestId("RecommendationRequestForm-requesterEmail").fill("djensen2@outlook.com");
+        page.getByTestId("RecommendationRequestForm-professorEmail").fill("pconrad@ucsb.edu");
+        page.getByTestId("RecommendationRequestForm-explanation").fill("masters program");
+        page.getByTestId("RecommendationRequestForm-dateRequested").pressSequentially("04260020240808A");
+        page.getByTestId("RecommendationRequestForm-dateNeeded").pressSequentially("04270020240808A");
+        page.getByTestId("RecommendationRequestForm-done").selectOption("true");
+        page.getByTestId("RecommendationRequestForm-submit").click();
+
+        assertThat(page.getByText("Date Needed is required.")).not().isVisible();
+
+        assertThat(page.getByTestId("RecommendationRequestTable-cell-row-0-col-requesterEmail")).hasText("djensen2@outlook.com");
+        assertThat(page.getByTestId("RecommendationRequestTable-cell-row-0-col-professorEmail")).hasText("pconrad@ucsb.edu");
+        assertThat(page.getByTestId("RecommendationRequestTable-cell-row-0-col-explanation")).hasText("masters program");
+        assertThat(page.getByTestId("RecommendationRequestTable-cell-row-0-col-dateRequested")).hasText("2024-04-26T08:08:00");
+        assertThat(page.getByTestId("RecommendationRequestTable-cell-row-0-col-dateNeeded")).hasText("2024-04-27T08:08:00");
+        assertThat(page.getByTestId("RecommendationRequestTable-cell-row-0-col-Done")).hasText("true");
+
+    }
+
+    @Test
+    public void regular_user_cant_create_recrequest() throws Exception{
+        setupUser(false);
+        page.getByText("Recommendation Requests").click();
+        assertThat(page.getByText("Create Recommendation Request")).not().isVisible();
+    }
+}

--- a/src/test/java/edu/ucsb/cs156/example/web/RestaurantWebIT.java
+++ b/src/test/java/edu/ucsb/cs156/example/web/RestaurantWebIT.java
@@ -34,7 +34,7 @@ public class RestaurantWebIT extends WebTestCase {
 
         page.getByTestId("RestaurantTable-cell-row-0-col-Edit-button").click();
         assertThat(page.getByText("Edit Restaurant")).isVisible();
-        page.getByTestId("RestaurantForm-description").fill("THE BESTEST");
+        page.getByTestId("RestaurantForm-description").fill("THE BEST");
         page.getByTestId("RestaurantForm-submit").click();
 
         assertThat(page.getByTestId("RestaurantTable-cell-row-0-col-description")).hasText("THE BESTEST");

--- a/src/test/java/edu/ucsb/cs156/example/web/RestaurantWebIT.java
+++ b/src/test/java/edu/ucsb/cs156/example/web/RestaurantWebIT.java
@@ -37,7 +37,7 @@ public class RestaurantWebIT extends WebTestCase {
         page.getByTestId("RestaurantForm-description").fill("THE BEST");
         page.getByTestId("RestaurantForm-submit").click();
 
-        assertThat(page.getByTestId("RestaurantTable-cell-row-0-col-description")).hasText("THE BESTEST");
+        assertThat(page.getByTestId("RestaurantTable-cell-row-0-col-description")).hasText("THE BEST");
 
         page.getByTestId("RestaurantTable-cell-row-0-col-Delete-button").click();
 

--- a/src/test/java/edu/ucsb/cs156/example/web/RestaurantWebIT.java
+++ b/src/test/java/edu/ucsb/cs156/example/web/RestaurantWebIT.java
@@ -34,10 +34,10 @@ public class RestaurantWebIT extends WebTestCase {
 
         page.getByTestId("RestaurantTable-cell-row-0-col-Edit-button").click();
         assertThat(page.getByText("Edit Restaurant")).isVisible();
-        page.getByTestId("RestaurantForm-description").fill("THE BEST");
+        page.getByTestId("RestaurantForm-description").fill("THE BESTEST");
         page.getByTestId("RestaurantForm-submit").click();
 
-        assertThat(page.getByTestId("RestaurantTable-cell-row-0-col-description")).hasText("THE BEST");
+        assertThat(page.getByTestId("RestaurantTable-cell-row-0-col-description")).hasText("THE BESTEST");
 
         page.getByTestId("RestaurantTable-cell-row-0-col-Delete-button").click();
 


### PR DESCRIPTION
In this PR, I added an end-to-end test for creating a Recommendation Request that adds it and then checks the table to see if it is in there. I also added an integration test for returning a singular Recommendation Request.

Additionally, for future use: when trying to fill in a date field, chromium for some reason uses 6 digit years, so on the field you can simply call `.pressSequentially(mmdd00yyyyhhmm<a|p>)` where a is for AM and p is for PM. 
For example, in my test, I call:
`page.getByTestId("RecommendationRequestForm-dateNeeded").pressSequentially("04270020240808A");`